### PR TITLE
Add support for multiple roles in OIDC Token

### DIFF
--- a/src/Czertainly.Auth/Data/Migrations/20220817165802_InitialCreate.Designer.cs
+++ b/src/Czertainly.Auth/Data/Migrations/20220817165802_InitialCreate.Designer.cs
@@ -169,6 +169,10 @@ namespace Czertainly.Auth.Data.Migrations
                         .HasColumnName("uuid")
                         .HasColumnOrder(0);
 
+                    b.Property<string>("AuthTokenSubjectId")
+                        .HasColumnType("text")
+                        .HasColumnName("auth_token_sub");
+
                     b.Property<string>("CertificateFingerprint")
                         .HasColumnType("text")
                         .HasColumnName("certificate_fingerprint");

--- a/src/Czertainly.Auth/Data/Migrations/20220817165802_InitialCreate.cs
+++ b/src/Czertainly.Auth/Data/Migrations/20220817165802_InitialCreate.cs
@@ -73,6 +73,7 @@ namespace Czertainly.Auth.Data.Migrations
                     system_user = table.Column<bool>(type: "boolean", nullable: false),
                     certificate_uuid = table.Column<Guid>(type: "uuid", nullable: true),
                     certificate_fingerprint = table.Column<string>(type: "text", nullable: true),
+                    auth_token_sub = table.Column<string>(type: "text", nullable: true),
                     created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
                     updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
                 },

--- a/src/Czertainly.Auth/Data/Migrations/AuthDbContextModelSnapshot.cs
+++ b/src/Czertainly.Auth/Data/Migrations/AuthDbContextModelSnapshot.cs
@@ -167,6 +167,10 @@ namespace Czertainly.Auth.Data.Migrations
                         .HasColumnName("uuid")
                         .HasColumnOrder(0);
 
+                    b.Property<string>("AuthTokenSubjectId")
+                        .HasColumnType("text")
+                        .HasColumnName("auth_token_sub");
+
                     b.Property<string>("CertificateFingerprint")
                         .HasColumnType("text")
                         .HasColumnName("certificate_fingerprint");

--- a/src/Czertainly.Auth/Models/Dto/AuthenticationTokenDto.cs
+++ b/src/Czertainly.Auth/Models/Dto/AuthenticationTokenDto.cs
@@ -8,7 +8,7 @@ namespace Czertainly.Auth.Models.Dto
     {
         [Required]
         [JsonPropertyName("sub")]
-        public Guid Uuid { get; init; }
+        public string SubjectId { get; init; }
 
         [Required]
         [JsonPropertyName("username")]
@@ -24,7 +24,7 @@ namespace Czertainly.Auth.Models.Dto
         public string Email { get; init; }
 
         [JsonPropertyName("roles")]
-        public string Roles { get; init; }
+        public string[] Roles { get; init; }
 
         public bool Enabled { get; init; } = true;
 

--- a/src/Czertainly.Auth/Models/Entities/User.cs
+++ b/src/Czertainly.Auth/Models/Entities/User.cs
@@ -39,6 +39,9 @@ public class User : TimestampedEntity
     [Column("certificate_fingerprint")]
     public string? CertificateFingerprint { get; set; }
 
+    [Column("auth_token_sub")]
+    public string? AuthTokenSubjectId { get; set; }
+
     public ICollection<Role> Roles { get; set; } = null!;
 
 }

--- a/src/Czertainly.Auth/Models/Mappings/UserProfile.cs
+++ b/src/Czertainly.Auth/Models/Mappings/UserProfile.cs
@@ -11,7 +11,8 @@ namespace Czertainly.Auth.Models.Mappings
         public UserProfile()
         {
             CreateMap<AuthenticationTokenDto, User>()
-                .ForMember(dest => dest.Roles, o => o.MapFrom(src => new List<Role>()));
+                .ForMember(dest => dest.Roles, o => o.MapFrom(src => new List<Role>()))
+                .ForMember(dest => dest.AuthTokenSubjectId, o => o.MapFrom(src => src.SubjectId));
             CreateMap<UserRequestDto, User>();
             CreateMap<UserUpdateRequestDto, User>();
             CreateMap<User, UserDto>();


### PR DESCRIPTION
- roles are specified as string array with role names
- roles are assigned if exists or created, and user does not yet have them assigned
- store sub property from token in DB as user auth token subject ID